### PR TITLE
Added command line options `distribution-file` and `output` for more custom usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,18 @@ $ bloom-release -r indigo -t indigo my_secrete_package
 ```
 
 Bloom will find your dependencies now.
+
+## Private distro files
+
+`rosdep-generator` deduces the URL of the `distribution.yaml` file from the
+given `org`, `repo`, and `rosdistro` command line parameters. However, if you
+are working locally, or not hosting your private rosdistro repo on github, you
+may override the full URL to the `distribution.yaml` file with the
+`--distribution-file` parameter. You may also specify a custom output filename
+with the `--output` parameter.
+
+Example:
+
+````
+$ ./rosdep-generator --distro indigo --distribution-file file:///home/user/foo-rosdistro/indigo/distribution.yaml -O ros-rosdistro-indigo-foo.yaml
+````

--- a/rosdep-generator
+++ b/rosdep-generator
@@ -9,9 +9,14 @@ parser = argparse.ArgumentParser(description="Generate rosdep key mapping so tha
 parser.add_argument("--org", default="ros", help="Github org from which to fetch rosdistro.")
 parser.add_argument("--repo", default="rosdistro", help="Github repo from which to fetch rosdistro.")
 parser.add_argument("--distro", default="indigo", help="Distro to generate for.")
+parser.add_argument("--distribution-file", default="", help="Override for the full url to a 'distribution.yaml' file. If not given, the URL is guessed from org, repo and rosdistro.")
+parser.add_argument("--output", "-O", default="", help="Override for the output file name. If not given, it `{org}-{repo}-{distro}.yaml` is used.")
 args = parser.parse_args()
 
-url = "https://github.com/%s/%s/raw/master/%s/distribution.yaml" % \
+if args.distribution_file:
+    url = args.distribution_file
+else:
+    url = "https://github.com/%s/%s/raw/master/%s/distribution.yaml" % \
         (args.org, args.repo, args.distro)
 
 print "Downloading: %s" % url
@@ -37,14 +42,17 @@ for package in packages:
     for platform in platforms:
         output_yaml[package][platform] = "ros-%s-%s" % (args.distro, package.replace("_", "-"))
 
-output_file = "%s-%s-%s.yaml" % (args.org, args.repo, args.distro)
+if args.output:
+    output_file = args.output
+else:
+    output_file = "%s-%s-%s.yaml" % (args.org, args.repo, args.distro)
 print "Outputting: %s" % output_file
 with open(output_file, "w") as f:
     yaml.dump(output_yaml, f)
 
 print "Complete. Suggested next steps:"
 print
-print '  sudo sh -c \'echo "yaml file://%s/%s %s" > /etc/ros/rosdep/sources.list.d/90-%s-%s-%s.list\'' % \
-        (os.getcwd(), output_file, args.distro, args.org, args.repo, args.distro)
+print '  sudo sh -c \'echo "yaml file://%s/%s %s" > /etc/ros/rosdep/sources.list.d/90-%s.list\'' % \
+        (os.getcwd(), output_file, args.distro, output_file.replace('.yaml', ''))
 print '  rosdep update'
 print


### PR DESCRIPTION
Just a little addition to work with more custom setups that don't have the rosdistro repo on github.

Thanks for the tool, its very helpful for managing a small private distro on top of indigo.
